### PR TITLE
Fix memory leak

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -32,8 +32,9 @@ pub fn readline(prompt: String) -> Option<String> {
         } else {
             let slice = CStr::from_ptr(ret);
             let res = str::from_utf8(slice.to_bytes())
-                .ok().expect("Failed to parse utf-8");
-            Some(res.to_string())
+                .ok().expect("Failed to parse utf-8").to_owned();
+            libc::free(slice.as_ptr() as *mut libc::c_void);
+            Some(res)
         }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -18,13 +18,13 @@ mod ext_readline {
 
 pub fn add_history(line: String) {
     unsafe {
-        let cline = CString::new(&(line.as_bytes())[..]).unwrap();
+        let cline = CString::new(line).unwrap();
         ext_readline::add_history(cline.as_ptr());
     }
 }
 
 pub fn readline(prompt: String) -> Option<String> {
-    let cprmt = CString::new(&(prompt.as_bytes())[..]).unwrap();
+    let cprmt = CString::new(prompt).unwrap();
     unsafe {
         let ret = ext_readline::readline(cprmt.as_ptr());
         if ret.is_null() {  // user pressed Ctrl-D


### PR DESCRIPTION
The string returned from ext_readline::readline is currently being leaked. From `readline(3)` man page:

> The line returned is allocated with malloc(3); the caller must free it when finished.

Fix by freeing the C string with `libc::free` before returning the owned copy of the string.