### PR TITLE
Add README and LICENSE

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+The MIT License (MIT)
+
+Copyright (c) Jason Ozias
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -1,0 +1,38 @@
+# readline-sys
+[![Build
+Status](https://travis-ci.org/rustyhorde/readline-sys.svg?branch=master)](https://travis-ci.org/rustyhorde/readline-sys)
+
+Native bindings to
+[libreadline](https://cnswww.cns.cwru.edu/php/chet/readline/rltop.html).
+
+## Features
+- thin wrappers around `readline` and `add_history`
+- write history line to file: `add_history_persist`
+- load history from file: `preload_history`
+
+## Usage
+Add `rl-sys` as a dependency in `Cargo.toml`
+
+```toml
+[dependencies]
+rl-sys = "0.1.2"
+```
+
+A simple implementation of `echo` using `rl_sys::readline`
+```rust
+extern crate rl_sys;
+
+fn main() {
+    let prompt = String::from("$ ");
+    loop {
+        let response = match rl_sys::readline(prompt) {
+            Some(s) => s,
+            None => break,
+        };
+        println!("{}", response);
+    }
+}
+```
+
+## License
+Distributed under the [MIT License](LICENSE).


### PR DESCRIPTION
This adds travis to README, an example `echo` program, and a brief
features summary. This also adds a LICENSE file corresponding to the
MIT license specified in Cargo.toml