### PR TITLE
Fixes to function pointers

### DIFF
--- a/src/readline/binding.rs
+++ b/src/readline/binding.rs
@@ -346,16 +346,20 @@ pub fn unbind_key_in_map(key: char, map: Keymap) -> BindResult {
 ///     Err(_)  => assert!(false),
 /// }
 ///
-///     Ok(res)  => assert!(res == 0),
 /// match binding::unbind_function_in_map(test_cmd_func, km) {
+///     Ok(res)  => assert!(res == 1),
 ///     Err(_) => assert!(false),
 /// }
 /// # }
 /// ```
 pub fn unbind_function_in_map(f: CommandFunction, map: Keymap) -> BindResult {
-    unsafe {
-        genresult(ext_binding::rl_unbind_function_in_map(f, map),
-                  "Unable to unbind key in map!")
+    let res = unsafe {
+        ext_binding::rl_unbind_function_in_map(f, map)
+    };
+    if res == 1 {
+        Ok(res)
+    } else {
+        Err(::ReadlineError::new("Binding Error", "Unable to unbind function!"))
     }
 }
 

--- a/src/readline/binding.rs
+++ b/src/readline/binding.rs
@@ -25,7 +25,7 @@ pub type BindResult = Result<i32, ::ReadlineError>;
 #[derive(Debug, PartialEq)]
 pub enum BindType {
     /// Generate a function binding.
-    Func(*mut Option<CommandFunction>),
+    Func(Option<CommandFunction>),
     /// Generate a keymap binding.
     Kmap(Keymap),
     /// Generate a macro binding.
@@ -35,7 +35,7 @@ pub enum BindType {
 impl From<i32> for BindType {
     fn from(i: i32) -> BindType {
         if i == 0 {
-            Func(ptr::null_mut())
+            Func(None)
         } else if i == 1 {
             Kmap(ptr::null_mut())
         } else if i == 2 {
@@ -51,34 +51,34 @@ mod ext_binding {
     use readline::{CommandFunction, Keymap};
 
     extern "C" {
-        pub fn rl_bind_key(key: c_int, f: *mut Option<CommandFunction>) -> c_int;
+        pub fn rl_bind_key(key: c_int, f: CommandFunction) -> c_int;
         pub fn rl_bind_key_in_map(key: c_int,
-                                  f: *mut Option<CommandFunction>,
+                                  f: CommandFunction,
                                   map: Keymap)
                                   -> c_int;
-        pub fn rl_bind_key_if_unbound(key: c_int, f: *mut Option<CommandFunction>) -> c_int;
+        pub fn rl_bind_key_if_unbound(key: c_int, f: CommandFunction) -> c_int;
         pub fn rl_bind_key_if_unbound_in_map(key: c_int,
-                                             f: *mut Option<CommandFunction>,
+                                             f: CommandFunction,
                                              map: Keymap)
                                              -> c_int;
         pub fn rl_unbind_key(key: c_int) -> c_int;
         pub fn rl_unbind_key_in_map(key: c_int, map: Keymap) -> c_int;
-        pub fn rl_unbind_function_in_map(f: *mut Option<CommandFunction>, map: Keymap) -> c_int;
+        pub fn rl_unbind_function_in_map(f: CommandFunction, map: Keymap) -> c_int;
         pub fn rl_unbind_command_in_map(cmd: *const c_char, map: Keymap) -> c_int;
-        pub fn rl_bind_keyseq(keyseq: *const c_char, f: *mut Option<CommandFunction>) -> c_int;
+        pub fn rl_bind_keyseq(keyseq: *const c_char, f: CommandFunction) -> c_int;
         pub fn rl_bind_keyseq_in_map(keyseq: *const c_char,
-                                     f: *mut Option<CommandFunction>,
+                                     f: CommandFunction,
                                      map: Keymap)
                                      -> c_int;
         pub fn rl_set_key(keyseq: *const c_char,
-                          f: *mut Option<CommandFunction>,
+                          f: CommandFunction,
                           map: Keymap)
                           -> c_int;
         pub fn rl_bind_keyseq_if_unbound(keyseq: *const c_char,
-                                         f: *mut Option<CommandFunction>)
+                                         f: CommandFunction)
                                          -> c_int;
         pub fn rl_bind_keyseq_if_unbound_in_map(keyseq: *const c_char,
-                                                f: *mut Option<CommandFunction>,
+                                                f: CommandFunction,
                                                 map: Keymap)
                                                 -> c_int;
         pub fn rl_generic_bind(bind_type: c_int,
@@ -117,13 +117,13 @@ fn genresult(res: i32, err: &str) -> BindResult {
 ///   0
 /// }
 ///
-/// match binding::bind_key('\t', &mut Some(test_cmd_func)) {
+/// match binding::bind_key('\t', test_cmd_func) {
 ///     Ok(res) => assert!(res == 0),
 ///     Err(_)  => assert!(false),
 /// }
 /// # }
 /// ```
-pub fn bind_key(key: char, f: *mut Option<CommandFunction>) -> BindResult {
+pub fn bind_key(key: char, f: CommandFunction) -> BindResult {
     unsafe {
         genresult(ext_binding::rl_bind_key(key as i32, f),
                   "Unable to bind key!")
@@ -149,13 +149,13 @@ pub fn bind_key(key: char, f: *mut Option<CommandFunction>) -> BindResult {
 ///
 /// let km = keymap::create_empty().unwrap();
 ///
-/// match binding::bind_key_in_map('\t', km, &mut Some(test_cmd_func)) {
+/// match binding::bind_key_in_map('\t', km, test_cmd_func) {
 ///     Ok(res) => assert!(res == 0),
 ///     Err(_)  => assert!(false),
 /// }
 /// # }
 /// ```
-pub fn bind_key_in_map(key: char, map: Keymap, f: *mut Option<CommandFunction>) -> BindResult {
+pub fn bind_key_in_map(key: char, map: Keymap, f: CommandFunction) -> BindResult {
     unsafe {
         genresult(ext_binding::rl_bind_key_in_map(key as i32, f, map),
                   "Unable to bind key in map!")
@@ -186,18 +186,18 @@ pub fn bind_key_in_map(key: char, map: Keymap, f: *mut Option<CommandFunction>) 
 /// let keymap = keymap::create_empty().unwrap();
 /// keymap::set(keymap);
 ///
-/// match binding::bind_key_if_unbound(';', &mut Some(test_cmd_func)) {
+/// match binding::bind_key_if_unbound(';', test_cmd_func) {
 ///     Ok(res) => assert!(res == 0),
 ///     Err(_)  => assert!(false),
 /// }
 ///
-/// match binding::bind_key_if_unbound(';', &mut Some(test_cmd_func)) {
+/// match binding::bind_key_if_unbound(';', test_cmd_func) {
 ///     Ok(_)  => assert!(false),
 ///     Err(_) => assert!(true),
 /// }
 /// # }
 /// ```
-pub fn bind_key_if_unbound(key: char, f: *mut Option<CommandFunction>) -> BindResult {
+pub fn bind_key_if_unbound(key: char, f: CommandFunction) -> BindResult {
     unsafe {
         genresult(ext_binding::rl_bind_key_if_unbound(key as i32, f),
                   "Unable to bind key!")
@@ -224,12 +224,12 @@ pub fn bind_key_if_unbound(key: char, f: *mut Option<CommandFunction>) -> BindRe
 ///
 /// let km = keymap::create_empty().unwrap();
 ///
-/// match binding::bind_key_if_unbound_in_map('\t', km, &mut Some(test_cmd_func)) {
+/// match binding::bind_key_if_unbound_in_map('\t', km, test_cmd_func) {
 ///     Ok(res) => assert!(res == 0),
 ///     Err(_)  => assert!(false),
 /// }
 ///
-/// match binding::bind_key_if_unbound_in_map('\t', km, &mut Some(test_cmd_func)) {
+/// match binding::bind_key_if_unbound_in_map('\t', km, test_cmd_func) {
 ///     Ok(_)  => assert!(false),
 ///     Err(_) => assert!(true),
 /// }
@@ -237,7 +237,7 @@ pub fn bind_key_if_unbound(key: char, f: *mut Option<CommandFunction>) -> BindRe
 /// ```
 pub fn bind_key_if_unbound_in_map(key: char,
                                   map: Keymap,
-                                  f: *mut Option<CommandFunction>)
+                                  f: CommandFunction)
                                   -> BindResult {
     unsafe {
         genresult(ext_binding::rl_bind_key_if_unbound_in_map(key as i32, f, map),
@@ -267,7 +267,7 @@ pub fn bind_key_if_unbound_in_map(key: char,
 ///
 /// let km = keymap::create_empty().unwrap();
 ///
-/// match binding::bind_key_if_unbound_in_map('\t', km, &mut Some(test_cmd_func)) {
+/// match binding::bind_key_if_unbound_in_map('\t', km, test_cmd_func) {
 ///     Ok(res) => assert!(res == 0),
 ///     Err(_)  => assert!(false),
 /// }
@@ -304,7 +304,7 @@ pub fn unbind_key(key: char) -> BindResult {
 ///
 /// let km = keymap::create_empty().unwrap();
 ///
-/// match binding::bind_key_if_unbound_in_map('\t', km, &mut Some(test_cmd_func)) {
+/// match binding::bind_key_if_unbound_in_map('\t', km, test_cmd_func) {
 ///     Ok(res) => assert!(res == 0),
 ///     Err(_)  => assert!(false),
 /// }
@@ -341,18 +341,18 @@ pub fn unbind_key_in_map(key: char, map: Keymap) -> BindResult {
 ///
 /// let km = keymap::create_empty().unwrap();
 ///
-/// match binding::bind_key_if_unbound_in_map('\t', km, &mut Some(test_cmd_func)) {
+/// match binding::bind_key_if_unbound_in_map('\t', km, test_cmd_func) {
 ///     Ok(res) => assert!(res == 0),
 ///     Err(_)  => assert!(false),
 /// }
 ///
-/// match binding::unbind_function_in_map(&mut Some(test_cmd_func), km) {
 ///     Ok(res)  => assert!(res == 0),
+/// match binding::unbind_function_in_map(test_cmd_func, km) {
 ///     Err(_) => assert!(false),
 /// }
 /// # }
 /// ```
-pub fn unbind_function_in_map(f: *mut Option<CommandFunction>, map: Keymap) -> BindResult {
+pub fn unbind_function_in_map(f: CommandFunction, map: Keymap) -> BindResult {
     unsafe {
         genresult(ext_binding::rl_unbind_function_in_map(f, map),
                   "Unable to unbind key in map!")
@@ -407,13 +407,13 @@ pub fn unbind_command_in_map(cmd: &str, map: Keymap) -> BindResult {
 ///   0
 /// }
 ///
-/// match binding::bind_keyseq("C-z", &mut Some(test_cmd_func)) {
+/// match binding::bind_keyseq("C-z", test_cmd_func) {
 ///     Ok(res) => assert!(res == 0),
 ///     Err(_)  => assert!(false),
 /// }
 /// # }
 /// ```
-pub fn bind_keyseq(keyseq: &str, f: *mut Option<CommandFunction>) -> BindResult {
+pub fn bind_keyseq(keyseq: &str, f: CommandFunction) -> BindResult {
     unsafe {
         let ptr = try!(CString::new(keyseq)).as_ptr();
         genresult(ext_binding::rl_bind_keyseq(ptr, f),
@@ -445,14 +445,14 @@ pub fn bind_keyseq(keyseq: &str, f: *mut Option<CommandFunction>) -> BindResult 
 ///
 /// assert!(!km.is_null());
 ///
-/// match binding::bind_keyseq_in_map("C-z", &mut Some(test_cmd_func), km) {
+/// match binding::bind_keyseq_in_map("C-z", test_cmd_func, km) {
 ///     Ok(res) => assert!(res == 0),
 ///     Err(_)  => assert!(false),
 /// }
 /// # }
 /// ```
 pub fn bind_keyseq_in_map(keyseq: &str,
-                          f: *mut Option<CommandFunction>,
+                          f: CommandFunction,
                           map: Keymap)
                           -> BindResult {
     unsafe {
@@ -484,13 +484,13 @@ pub fn bind_keyseq_in_map(keyseq: &str,
 ///
 /// assert!(!km.is_null());
 ///
-/// match binding::set_key("C-z", &mut Some(test_cmd_func), km) {
+/// match binding::set_key("C-z", test_cmd_func, km) {
 ///     Ok(res) => assert!(res == 0),
 ///     Err(_)  => assert!(false),
 /// }
 /// # }
 /// ```
-pub fn set_key(keyseq: &str, f: *mut Option<CommandFunction>, map: Keymap) -> BindResult {
+pub fn set_key(keyseq: &str, f: CommandFunction, map: Keymap) -> BindResult {
     unsafe {
         let ptr = try!(CString::new(keyseq)).as_ptr();
         genresult(ext_binding::rl_set_key(ptr, f, map),
@@ -516,18 +516,18 @@ pub fn set_key(keyseq: &str, f: *mut Option<CommandFunction>, map: Keymap) -> Bi
 ///   0
 /// }
 ///
-/// match binding::bind_keyseq_if_unbound("C-z", &mut Some(test_cmd_func)) {
+/// match binding::bind_keyseq_if_unbound("C-z", test_cmd_func) {
 ///     Ok(res) => assert!(res == 0),
 ///     Err(_)  => assert!(false),
 /// }
 ///
-/// match binding::bind_keyseq_if_unbound("C-z", &mut Some(test_cmd_func)) {
+/// match binding::bind_keyseq_if_unbound("C-z", test_cmd_func) {
 ///     Ok(_)  => assert!(false),
 ///     Err(_) => assert!(true),
 /// }
 /// # }
 /// ```
-pub fn bind_keyseq_if_unbound(keyseq: &str, f: *mut Option<CommandFunction>) -> BindResult {
+pub fn bind_keyseq_if_unbound(keyseq: &str, f: CommandFunction) -> BindResult {
     unsafe {
         let ptr = try!(CString::new(keyseq)).as_ptr();
         genresult(ext_binding::rl_bind_keyseq_if_unbound(ptr, f),
@@ -558,19 +558,19 @@ pub fn bind_keyseq_if_unbound(keyseq: &str, f: *mut Option<CommandFunction>) -> 
 ///
 /// assert!(!km.is_null());
 ///
-/// match binding::bind_keyseq_if_unbound_in_map("C-z", &mut Some(test_cmd_func), km) {
+/// match binding::bind_keyseq_if_unbound_in_map("C-z", test_cmd_func, km) {
 ///     Ok(res) => assert!(res == 0),
 ///     Err(_)  => assert!(false),
 /// }
 ///
-/// match binding::bind_keyseq_if_unbound_in_map("C-z", &mut Some(test_cmd_func), km) {
+/// match binding::bind_keyseq_if_unbound_in_map("C-z", test_cmd_func, km) {
 ///     Ok(_)  => assert!(false),
 ///     Err(_) => assert!(true),
 /// }
 /// # }
 /// ```
 pub fn bind_keyseq_if_unbound_in_map(keyseq: &str,
-                                     f: *mut Option<CommandFunction>,
+                                     f: CommandFunction,
                                      map: Keymap)
                                      -> BindResult {
     unsafe {
@@ -607,7 +607,7 @@ pub fn bind_keyseq_if_unbound_in_map(keyseq: &str,
 ///
 /// assert!(!km.is_null());
 ///
-/// match binding::generic_bind("C-z", BindType::Func(&mut Some(test_cmd_func)), km) {
+/// match binding::generic_bind("C-z", BindType::Func(Some(test_cmd_func)), km) {
 ///     Ok(res) => assert!(res == 0),
 ///     Err(_)  => assert!(false),
 /// }
@@ -634,7 +634,12 @@ pub fn generic_bind(keyseq: &str, bind_type: BindType, map: Keymap) -> BindResul
 
         match bind_type {
             Func(func_ptr) => {
-                genresult(ext_binding::rl_generic_bind(0, ptr, func_ptr as *mut i8, map),
+                let fptr = if func_ptr.is_some() {
+                    func_ptr.unwrap() as *mut i8
+                } else {
+                    ::std::ptr::null_mut() as *mut i8
+                };
+                genresult(ext_binding::rl_generic_bind(0, ptr, fptr, map),
                           "Unable to bind to function!")
             }
             Kmap(km) => {

--- a/src/readline/mod.rs
+++ b/src/readline/mod.rs
@@ -51,7 +51,7 @@ mod ext_readline {
     extern "C" {
         pub fn readline(p: *const c_char) -> *const c_char;
         pub fn rl_callback_handler_install(p: *const c_char,
-                                           lhandler: *mut Option<HandlerFunction>)
+                                           lhandler: Option<HandlerFunction>)
                                            -> ();
         pub fn rl_callback_read_char() -> ();
         pub fn rl_callback_handler_remove() -> ();
@@ -181,7 +181,7 @@ pub struct KeymapEntry {
     /// Keymap Type
     pub type_: c_char,
     /// Keymap Function
-    pub kfunc: *mut Option<extern "C" fn() -> c_int>,
+    pub kfunc: Option<extern "C" fn() -> c_int>,
 }
 
 impl Default for KeymapEntry {
@@ -215,7 +215,7 @@ pub struct ReadlineState {
     /// The current keymap.
     pub kmap: Keymap,
     /// The last function executed.
-    pub lastfunc: *mut Option<extern "C" fn() -> c_int>,
+    pub lastfunc: Option<extern "C" fn() -> c_int>,
     /// The insert mode.
     pub insmode: c_int,
     /// The edit mode.
@@ -348,7 +348,7 @@ pub fn readline(prompt: &str) -> Result<Option<String>, ::ReadlineError> {
 /// the value of `lhandler` to use as a handler function to call when a complete line of input has
 /// been entered. The handler function receives the text of the line as an argument.
 pub fn callback_handler_install(p: &str,
-                                lhandler: *mut Option<HandlerFunction>)
+                                lhandler: Option<HandlerFunction>)
                                 -> Result<(), ::ReadlineError> {
     let ptr = try!(CString::new(p)).as_ptr();
 


### PR DESCRIPTION
This PR fixes invalid nullable function pointers, essentially changing incorrect `*mut Option<FunctionType>` pointers to correct `Option<FunctionType>`. Also fixes some functions that used to take nullable function pointers to take non-nullable function pointers to prevent user errors. Fixes issue #9.