### PR TITLE
Fix `as_ptr` usage

### DIFF
--- a/src/history/expand.rs
+++ b/src/history/expand.rs
@@ -80,14 +80,14 @@ pub fn expand(s: &str) -> Result<(isize, String), ::HistoryError> {
 /// ```
 pub fn get_event(s: &str, idx: &mut i32, delim: Option<char>) -> Result<String, ::HistoryError> {
     init();
-    let ptr = try!(CString::new(s)).as_ptr();
+    let cs = try!(CString::new(s));
     let ch = match delim {
         Some(c) => c as c_int,
         None => 0 as c_int,
     };
 
     unsafe {
-        let char_ptr = ext_expand::get_history_event(ptr, idx as *mut c_int, ch);
+        let char_ptr = ext_expand::get_history_event(cs.as_ptr(), idx as *mut c_int, ch);
 
         if char_ptr.is_null() {
             Err(::HistoryError::new("History Error", "Null pointer returned!"))
@@ -115,12 +115,12 @@ pub fn get_event(s: &str, idx: &mut i32, delim: Option<char>) -> Result<String, 
 /// ```
 pub fn tokenize(s: &str) -> Result<Vec<String>, ::HistoryError> {
     init();
-    let ptr = try!(CString::new(s)).as_ptr();
+    let cs = try!(CString::new(s));
     let mut res = Vec::new();
 
     unsafe {
         // Returns a char **.  The last entry is 0x0.
-        let arr_ptr = ext_expand::history_tokenize(ptr);
+        let arr_ptr = ext_expand::history_tokenize(cs.as_ptr());
 
         if arr_ptr.is_null() {
             Err(::HistoryError::new("History Error", "Null pointer returned!"))
@@ -165,9 +165,9 @@ pub fn tokenize(s: &str) -> Result<Vec<String>, ::HistoryError> {
 /// ```
 pub fn arg_extract(s: &str, first: i32, last: i32) -> Result<String, ::HistoryError> {
     init();
-    let ptr = try!(CString::new(s)).as_ptr();
+    let cs = try!(CString::new(s));
     unsafe {
-        let char_ptr = ext_expand::history_arg_extract(first, last, ptr);
+        let char_ptr = ext_expand::history_arg_extract(first, last, cs.as_ptr());
 
         if char_ptr.is_null() {
             Err(::HistoryError::new("History Error", "Null pointer returned!"))

--- a/src/history/listmgmt.rs
+++ b/src/history/listmgmt.rs
@@ -43,10 +43,10 @@ mod ext_listmgmt {
 /// ```
 pub fn add(line: &str) -> Result<(), ::HistoryError> {
     init();
-    let ptr = try!(CString::new(line)).as_ptr();
+    let csline = try!(CString::new(line));
 
     unsafe {
-        ext_listmgmt::add_history(ptr);
+        ext_listmgmt::add_history(csline.as_ptr());
     }
 
     Ok(())
@@ -79,9 +79,9 @@ pub fn add_time(time: Timespec) -> Result<(), ::HistoryError> {
         Ok(())
     } else {
         let now_str = format!("{}{}", cc, time.sec);
-        let ptr = try!(CString::new(now_str)).as_ptr();
+        let cstime = try!(CString::new(now_str));
         unsafe {
-            ext_listmgmt::add_history_time(ptr);
+            ext_listmgmt::add_history_time(cstime.as_ptr());
         }
         Ok(())
     }
@@ -148,14 +148,14 @@ pub fn replace_entry(offset: i32,
                      appdata: Option<*mut c_void>)
                      -> Result<&mut HistoryEntry, ::HistoryError> {
     init();
-    let line_ptr = try!(CString::new(line)).as_ptr();
+    let csline = try!(CString::new(line));
     let ptr = match appdata {
         Some(d) => d,
         None => ptr::null_mut(),
     };
 
     unsafe {
-        let old_entry = ext_listmgmt::replace_history_entry(offset, line_ptr, ptr);
+        let old_entry = ext_listmgmt::replace_history_entry(offset, csline.as_ptr(), ptr);
 
         if old_entry.is_null() {
             Err(::HistoryError::new("Null Pointer", "Invalid replace requested!"))

--- a/src/history/search.rs
+++ b/src/history/search.rs
@@ -56,8 +56,8 @@ pub fn search<T>(s: &str, dir: T) -> Result<isize, ::HistoryError>
     where T: Into<i32>
 {
     init();
-    let ptr = try!(CString::new(s)).as_ptr();
-    unsafe { Ok(ext_search::history_search(ptr, dir.into()) as isize) }
+    let cs = try!(CString::new(s));
+    unsafe { Ok(ext_search::history_search(cs.as_ptr(), dir.into()) as isize) }
 }
 
 /// Search the history for string, starting at the current history offset. The search is anchored:
@@ -82,8 +82,8 @@ pub fn search_prefix<T>(s: &str, dir: T) -> Result<isize, ::HistoryError>
     where T: Into<i32>
 {
     init();
-    let ptr = try!(CString::new(s)).as_ptr();
-    unsafe { Ok(ext_search::history_search_prefix(ptr, dir.into()) as isize) }
+    let cs = try!(CString::new(s));
+    unsafe { Ok(ext_search::history_search_prefix(cs.as_ptr(), dir.into()) as isize) }
 }
 
 /// Search for string in the history list, starting at pos, an absolute index into the list. If
@@ -104,6 +104,6 @@ pub fn search_pos<T>(s: &str, dir: T, pos: i32) -> Result<isize, ::HistoryError>
     where T: Into<i32>
 {
     init();
-    let ptr = try!(CString::new(s)).as_ptr();
-    unsafe { Ok(ext_search::history_search_pos(ptr, dir.into(), pos) as isize) }
+    let cs = try!(CString::new(s));
+    unsafe { Ok(ext_search::history_search_pos(cs.as_ptr(), dir.into(), pos) as isize) }
 }

--- a/src/readline/keymap.rs
+++ b/src/readline/keymap.rs
@@ -176,9 +176,9 @@ pub fn set(map: Keymap) -> () {
 /// assert!(!keymap.is_null());
 /// ```
 pub fn get_by_name(name: &str) -> Result<Keymap, ::ReadlineError> {
-    let name_ptr = try!(CString::new(name)).as_ptr();
+    let csname = try!(CString::new(name));
     unsafe {
-        let keymap_ptr = ext_keymap::rl_get_keymap_by_name(name_ptr);
+        let keymap_ptr = ext_keymap::rl_get_keymap_by_name(csname.as_ptr());
 
         if keymap_ptr.is_null() {
             Err(::ReadlineError::new("Null Pointer",

--- a/src/readline/misc.rs
+++ b/src/readline/misc.rs
@@ -50,10 +50,10 @@ pub fn macro_dumper(readable: bool) -> () {
 /// assert!(misc::variable_bind("comment-begin", "<").is_ok());
 /// ```
 pub fn variable_bind(name: &str, val: &str) -> Result<i32, ::ReadlineError> {
-    let name_ptr = try!(CString::new(name)).as_ptr();
-    let val_ptr = try!(CString::new(val)).as_ptr();
+    let csname = try!(CString::new(name));
+    let csval = try!(CString::new(val));
 
-    unsafe { Ok(ext_misc::rl_variable_bind(name_ptr, val_ptr)) }
+    unsafe { Ok(ext_misc::rl_variable_bind(csname.as_ptr(), csval.as_ptr())) }
 }
 
 /// Return a string representing the value of the Readline variable `name`. For boolean variables,
@@ -78,17 +78,16 @@ pub fn variable_bind(name: &str, val: &str) -> Result<i32, ::ReadlineError> {
 /// }
 /// ```
 pub fn variable_value(name: &str) -> Result<String, ::ReadlineError> {
-    let name_ptr = try!(CString::new(name)).as_ptr();
+    let csname = try!(CString::new(name));
 
-    unsafe {
-        let val_ptr = ext_misc::rl_variable_value(name_ptr);
-
-        if val_ptr.is_null() {
-            Err(::ReadlineError::new("Misc Error",
-                                     "Null pointer returned from rl_variable_value!"))
-        } else {
-            Ok(CStr::from_ptr(val_ptr).to_string_lossy().into_owned())
-        }
+    let val_ptr = unsafe {
+        ext_misc::rl_variable_value(csname.as_ptr())
+    };
+    if val_ptr.is_null() {
+        Err(::ReadlineError::new("Misc Error",
+                                 "Null pointer returned from rl_variable_value!"))
+    } else {
+        Ok(unsafe { CStr::from_ptr(val_ptr).to_string_lossy().into_owned() })
     }
 }
 
@@ -154,16 +153,15 @@ pub fn set_paren_blink_timeout(us: i32) -> Result<i32, ::ReadlineError> {
 /// }
 /// ```
 pub fn get_termcap(cap: &str) -> Result<String, ::ReadlineError> {
-    let ptr = try!(CString::new(cap)).as_ptr();
+    let cscap = try!(CString::new(cap));
 
-    unsafe {
-        let cap_ptr = ext_misc::rl_get_termcap(ptr);
-
-        if cap_ptr.is_null() {
-            Err(::ReadlineError::new("Misc Error", "rl_get_termcap returned a null pointer!"))
-        } else {
-            Ok(CStr::from_ptr(cap_ptr).to_string_lossy().into_owned())
-        }
+    let cap_ptr = unsafe {
+        ext_misc::rl_get_termcap(cscap.as_ptr())
+    };
+    if cap_ptr.is_null() {
+        Err(::ReadlineError::new("Misc Error", "rl_get_termcap returned a null pointer!"))
+    } else {
+        Ok(unsafe { CStr::from_ptr(cscap.as_ptr()).to_string_lossy().into_owned() })
     }
 }
 

--- a/src/readline/mod.rs
+++ b/src/readline/mod.rs
@@ -321,14 +321,16 @@ impl Default for UndoList {
 /// }
 /// ```
 pub fn readline(prompt: &str) -> Result<Option<String>, ::ReadlineError> {
-    let prompt_ptr = try!(CString::new(prompt)).as_ptr();
+    let csprompt = try!(CString::new(prompt));
 
-    unsafe {
-        let ret = ext_readline::readline(prompt_ptr);
-        if ret.is_null() {
-            // user pressed Ctrl-D
-            Ok(None)
-        } else {
+    let ret = unsafe {
+        ext_readline::readline(csprompt.as_ptr())
+    };
+    if ret.is_null() {
+        // user pressed Ctrl-D
+        Ok(None)
+    } else {
+        unsafe {
             let line = CStr::from_ptr(ret).to_string_lossy().into_owned();
             free(ret as *mut c_void);
             Ok(Some(line))
@@ -350,9 +352,9 @@ pub fn readline(prompt: &str) -> Result<Option<String>, ::ReadlineError> {
 pub fn callback_handler_install(p: &str,
                                 lhandler: Option<HandlerFunction>)
                                 -> Result<(), ::ReadlineError> {
-    let ptr = try!(CString::new(p)).as_ptr();
+    let cp = try!(CString::new(p));
 
-    unsafe { Ok(ext_readline::rl_callback_handler_install(ptr, lhandler)) }
+    unsafe { Ok(ext_readline::rl_callback_handler_install(cp.as_ptr(), lhandler)) }
 }
 
 /// Whenever an application determines that keyboard input is available, it should call

--- a/src/readline/modtext.rs
+++ b/src/readline/modtext.rs
@@ -35,10 +35,10 @@ fn genresult(res: i32, message: &str) -> Result<i32, ::ReadlineError> {
 /// assert!(modtext::insert_text("inserted").is_ok());
 /// ```
 pub fn insert_text(text: &str) -> Result<i32, ::ReadlineError> {
-    let ptr = try!(CString::new(text)).as_ptr();
+    let cstext = try!(CString::new(text));
 
     unsafe {
-        let res = ext_modtext::rl_insert_text(ptr);
+        let res = ext_modtext::rl_insert_text(cstext.as_ptr());
 
         if res > 0 {
             Ok(res)
@@ -135,6 +135,6 @@ pub fn kill_text(start: i32, end: i32) -> Result<i32, ::ReadlineError> {
 /// assert!(modtext::push_macro_input("\\C-e | less\\C-m").is_ok());
 /// ```
 pub fn push_macro_input(m: &str) -> Result<(), ::ReadlineError> {
-    let ptr = try!(CString::new(m)).as_ptr();
-    unsafe { Ok(ext_modtext::rl_push_macro_input(ptr)) }
+    let csm = try!(CString::new(m));
+    unsafe { Ok(ext_modtext::rl_push_macro_input(csm.as_ptr())) }
 }

--- a/src/readline/naming.rs
+++ b/src/readline/naming.rs
@@ -49,7 +49,7 @@ mod ext_naming {
 /// ```
 pub fn add_func(name: &str, key: char, f: CommandFunction) -> Result<i32, ::ReadlineError> {
     unsafe {
-        let ptr = try!(CString::new(name)).as_ptr();
-        Ok(ext_naming::rl_add_defun(ptr, f as *mut CommandFunction, key as i32))
+        let csname = try!(CString::new(name));
+        Ok(ext_naming::rl_add_defun(csname.as_ptr(), f as *mut CommandFunction, key as i32))
     }
 }

--- a/src/readline/redisplay.rs
+++ b/src/readline/redisplay.rs
@@ -228,8 +228,8 @@ pub fn show_char(c: char) -> Result<i32, ::ReadlineError> {
 /// assert!(redisplay::clear_message().is_ok());
 /// ```
 pub fn message(message: &str) -> Result<i32, ::ReadlineError> {
-    let ptr = try!(CString::new(message)).as_ptr();
-    unsafe { genresult(ext_redisplay::rl_message(ptr), "Unable to show message!") }
+    let csmessage = try!(CString::new(message));
+    unsafe { genresult(ext_redisplay::rl_message(csmessage.as_ptr()), "Unable to show message!") }
 }
 
 /// Clear the message in the echo area. If the prompt was saved with a call to `rl_save_prompt`
@@ -313,9 +313,9 @@ pub fn rl_restore_prompt() -> () {
 /// assert!(redisplay::expand_prompt("test message").is_ok());
 /// ```
 pub fn expand_prompt(prompt: &str) -> Result<i32, ::ReadlineError> {
-    let ptr = try!(CString::new(prompt)).as_ptr();
+    let csprompt = try!(CString::new(prompt));
     unsafe {
-        let res = ext_redisplay::rl_expand_prompt(ptr);
+        let res = ext_redisplay::rl_expand_prompt(csprompt.as_ptr());
 
         if res > 0 {
             Ok(res)
@@ -338,6 +338,6 @@ pub fn expand_prompt(prompt: &str) -> Result<i32, ::ReadlineError> {
 /// assert!(redisplay::set_prompt("NEW PROMPT: ").is_ok());
 /// ```
 pub fn set_prompt(prompt: &str) -> Result<i32, ::ReadlineError> {
-    let ptr = try!(CString::new(prompt)).as_ptr();
-    unsafe { genresult(ext_redisplay::rl_set_prompt(ptr), "Unable to set prompt!") }
+    let csprompt = try!(CString::new(prompt));
+    unsafe { genresult(ext_redisplay::rl_set_prompt(csprompt.as_ptr()), "Unable to set prompt!") }
 }

--- a/src/readline/termmgmt.rs
+++ b/src/readline/termmgmt.rs
@@ -100,17 +100,18 @@ pub fn tty_unset_default_bindings(kmap: Keymap) -> () {
 /// assert!(termmgmt::reset_terminal(None).is_ok());
 /// ```
 pub fn reset_terminal(name: Option<&str>) -> Result<i32, ::ReadlineError> {
-    let ptr = match name {
-        Some(s) => try!(CString::new(s)).as_ptr(),
-        None => ptr::null(),
-    };
-    unsafe {
-        let res = ext_termmgmt::rl_reset_terminal(ptr);
-
-        if res == 0 {
-            Ok(res)
-        } else {
-            Err(::ReadlineError::new("Termmgmt Error", "Unable to reset terminal!"))
+    let res = match name {
+        Some(s) => {
+            let cs = try!(CString::new(s));
+            unsafe { ext_termmgmt::rl_reset_terminal(cs.as_ptr()) }
+        },
+        None => {
+            unsafe { ext_termmgmt::rl_reset_terminal(ptr::null()) }
         }
+    };
+    if res == 0 {
+        Ok(res)
+    } else {
+        Err(::ReadlineError::new("Termmgmt Error", "Unable to reset terminal!"))
     }
 }

--- a/src/readline/util.rs
+++ b/src/readline/util.rs
@@ -111,10 +111,10 @@ pub fn free(ptr: *mut c_void) {
 /// assert!(util::replace_line("replacement", false).is_ok());
 /// ```
 pub fn replace_line(text: &str, clear_undo: bool) -> Result<(), ::ReadlineError> {
-    let ptr = try!(CString::new(text)).as_ptr();
+    let cstext = try!(CString::new(text));
     let clear = if clear_undo { 1 } else { 0 };
 
-    unsafe { Ok(ext_util::rl_replace_line(ptr, clear)) }
+    unsafe { Ok(ext_util::rl_replace_line(cstext.as_ptr(), clear)) }
 }
 
 /// Ensure that `rl_line_buffer` has enough space to hold len characters, possibly reallocating it


### PR DESCRIPTION
As far as I know, `try!(CString::new(s)).as_ptr()` even though it looks like it works (and in some cases it might actually work in practice), is not correct and results in undefined behavior. The thing is that `.as_ptr()`, according to the documentation will be valid for as long as `self` is and in this case, `self` is valid only during that statement.

This PR changes all occurrences of the pattern `try!(CString::new(s)).as_ptr()` to explicitly bind `try!(CString::new(s))` to a variable and calling `.as_ptr()` with a valid CString.